### PR TITLE
rpaas: add extension points to http and server blocks in nginx.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ local_modules
 *.tar.gz
 .vagrant
 *.zip
-consul

--- a/rpaas/files/check_file.sh
+++ b/rpaas/files/check_file.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ -f $1 ]; then
+    cat $1
+fi
+
+exit 0

--- a/rpaas/files/check_healthcheck.sh
+++ b/rpaas/files/check_healthcheck.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-if [ -f /etc/nginx/sites-enabled/consul/locations.conf ]; then
-    cat /etc/nginx/sites-enabled/consul/locations.conf
-fi
-
-exit 0

--- a/rpaas/manifests/init.pp
+++ b/rpaas/manifests/init.pp
@@ -21,6 +21,7 @@ class rpaas {
                   '/etc/nginx/sites-enabled',
                   '/etc/nginx/sites-enabled/dav',
                   '/etc/nginx/sites-enabled/consul',
+                  '/etc/nginx/sites-enabled/consul/blocks',
                   $dav_ssl_dir,
                   $consul_ssl_dir ]
 }

--- a/rpaas/manifests/install.pp
+++ b/rpaas/manifests/install.pp
@@ -125,15 +125,27 @@ class rpaas::install (
       require => File['/etc/consul-template.d/templates']
     }
 
+    file { '/etc/consul-template.d/templates/block_http.conf.tpl':
+      ensure  => file,
+      content => template('rpaas/consul/block_http.conf.tpl.erb'),
+      require => File['/etc/consul-template.d/templates']
+    }
+
+    file { '/etc/consul-template.d/templates/block_server.conf.tpl':
+      ensure  => file,
+      content => template('rpaas/consul/block_server.conf.tpl.erb'),
+      require => File['/etc/consul-template.d/templates']
+    }
+
     file { '/etc/consul-template.d/plugins/check_nginx_ssl_data.sh':
       ensure  => file,
       source  => 'puppet:///modules/rpaas/check_nginx_ssl_data.sh',
       require => File['/etc/consul-template.d/plugins']
     }
 
-    file { '/etc/consul-template.d/plugins/check_healthcheck.sh':
+    file { '/etc/consul-template.d/plugins/check_file.sh':
       ensure  => file,
-      source  => 'puppet:///modules/rpaas/check_healthcheck.sh',
+      source  => 'puppet:///modules/rpaas/check_file.sh',
       require => File['/etc/consul-template.d/plugins']
     }
 
@@ -151,6 +163,8 @@ class rpaas::install (
                       File['/etc/consul-template.d/templates/locations.conf.tpl'],
                       File['/etc/consul-template.d/templates/nginx.key.tpl'],
                       File['/etc/consul-template.d/templates/nginx.crt.tpl'],
+                      File['/etc/consul-template.d/templates/block_http.conf.tpl'],
+                      File['/etc/consul-template.d/templates/block_server.conf.tpl'],
                       File['/etc/consul-template.d/plugins/check_nginx_ssl_data.sh'],
                       File['/etc/nginx/certs'],
                       File['/etc/consul-template.d/plugins/check_and_reload_nginx.sh'] ],
@@ -159,10 +173,23 @@ class rpaas::install (
                       File['/etc/consul-template.d/templates/locations.conf.tpl'],
                       File['/etc/consul-template.d/templates/nginx.key.tpl'],
                       File['/etc/consul-template.d/templates/nginx.crt.tpl'],
+                      File['/etc/consul-template.d/templates/block_http.conf.tpl'],
+                      File['/etc/consul-template.d/templates/block_server.conf.tpl'],
                       File['/etc/consul-template.d/plugins/check_nginx_ssl_data.sh'],
                       File['/etc/nginx/certs'] ]
     }
 
+    file { '/etc/nginx/sites-enabled/consul/blocks/http.conf':
+      ensure  => file,
+      replace => false,
+      require => File['/etc/nginx/sites-enabled/consul/blocks']
+    }
+
+    file { '/etc/nginx/sites-enabled/consul/blocks/server.conf':
+      ensure  => file,
+      replace => false,
+      require => File['/etc/nginx/sites-enabled/consul/blocks']
+    }
   }
 
   package { 'nginx-extras':

--- a/rpaas/spec/classes/rpaas_install_spec.rb
+++ b/rpaas/spec/classes/rpaas_install_spec.rb
@@ -193,6 +193,31 @@ EOF
     )
     end
 
+    it 'generate block templates file for consul' do
+      should contain_file('/etc/consul-template.d/templates/block_http.conf.tpl').with_content(<<EOF
+{{ with key_or_default "rpaas_fe/foo_instance/healthcheck" "" }}
+  {{ key_or_default "rpaas_fe/foo_instance/blocks/http/ROOT" "" }}
+{{ else }}
+  {{ plugin "check_file.sh" "/etc/consul-template.d/templates/block_http.conf.tpl" }}
+{{ end }}
+EOF
+      )
+
+      should contain_file('/etc/consul-template.d/templates/block_server.conf.tpl').with_content(<<EOF
+{{ with key_or_default "rpaas_fe/foo_instance/healthcheck" "" }}
+  {{ key_or_default "rpaas_fe/foo_instance/blocks/server/ROOT" "" }}
+{{ else }}
+  {{ plugin "check_file.sh" "/etc/consul-template.d/templates/block_server.conf.tpl" }}
+{{ end }}
+EOF
+      )
+    end
+
+    it 'generate initial empty block files' do
+      should contain_file('/etc/nginx/sites-enabled/consul/blocks/http.conf')
+      should contain_file('/etc/nginx/sites-enabled/consul/blocks/server.conf')
+    end
+
     consul_conf_content = <<EOF
 consul = "foo.bar:8500"
 token = "0000-1111"

--- a/rpaas/templates/consul/block_http.conf.tpl.erb
+++ b/rpaas/templates/consul/block_http.conf.tpl.erb
@@ -1,0 +1,5 @@
+{{ with key_or_default "<%= @rpaas_service_name %>/<%= @rpaas_instance_name %>/healthcheck" "" }}
+  {{ key_or_default "<%= @rpaas_service_name %>/<%= @rpaas_instance_name %>/blocks/http/ROOT" "" }}
+{{ else }}
+  {{ plugin "check_file.sh" "/etc/consul-template.d/templates/block_http.conf.tpl" }}
+{{ end }}

--- a/rpaas/templates/consul/block_server.conf.tpl.erb
+++ b/rpaas/templates/consul/block_server.conf.tpl.erb
@@ -1,0 +1,5 @@
+{{ with key_or_default "<%= @rpaas_service_name %>/<%= @rpaas_instance_name %>/healthcheck" "" }}
+  {{ key_or_default "<%= @rpaas_service_name %>/<%= @rpaas_instance_name %>/blocks/server/ROOT" "" }}
+{{ else }}
+  {{ plugin "check_file.sh" "/etc/consul-template.d/templates/block_server.conf.tpl" }}
+{{ end }}

--- a/rpaas/templates/consul/consul.conf.erb
+++ b/rpaas/templates/consul/consul.conf.erb
@@ -26,3 +26,17 @@ template {
     command = "/etc/consul-template.d/plugins/check_and_reload_nginx.sh"
     perms = 0644
 }
+
+template {
+    source = "/etc/consul-template.d/templates/block_http.conf.tpl"
+    destination = "/etc/nginx/sites-enabled/consul/blocks/http.conf"
+    command = "/etc/consul-template.d/plugins/check_and_reload_nginx.sh"
+    perms = 0644
+}
+
+template {
+    source = "/etc/consul-template.d/templates/block_server.conf.tpl"
+    destination = "/etc/nginx/sites-enabled/consul/blocks/server.conf"
+    command = "/etc/consul-template.d/plugins/check_and_reload_nginx.sh"
+    perms = 0644
+}

--- a/rpaas/templates/consul/locations.conf.tpl.erb
+++ b/rpaas/templates/consul/locations.conf.tpl.erb
@@ -8,5 +8,5 @@ location /_nginx_healthcheck/ {
 {{ .Value }}
 {{ end }}
 {{ else }}
-{{ plugin "check_healthcheck.sh" }}
+{{ plugin "check_file.sh" "/etc/nginx/sites-enabled/consul/locations.conf" }}
 {{ end }}

--- a/rpaas/templates/nginx.conf.erb
+++ b/rpaas/templates/nginx.conf.erb
@@ -85,6 +85,10 @@ http {
 <% end -%>
     }
 
+<% if @nginx_mechanism == 'consul' -%>
+    include sites-enabled/consul/blocks/http.conf;
+<% end -%>
+
     server {
         listen <%= @nginx_listen %>;
         listen <%= @nginx_ssl_listen %> ssl spdy;
@@ -140,6 +144,7 @@ http {
         include sites-enabled/dav/*.conf;
 <% else -%>
         include sites-enabled/consul/*.conf;
+        include sites-enabled/consul/blocks/server.conf;
 <% end -%>
     }
 }


### PR DESCRIPTION
rpaas api server is already writing Consul keys for http and server blocks.
